### PR TITLE
Add venv into tox.ini to be able to run commands

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,9 @@ basepython = python3.4
 [testenv:py35]
 basepython = python3.5
 
+[testenv:venv]
+commands = {posargs}
+
 [testenv:yamllint]
 deps = yamllint
 commands = {toxinidir}/tools/yamllint.sh


### PR DESCRIPTION
This target could be usefull to run arbitrary commands under the tox
virtualenv, e.g.:

    tox -e venv -- availability-api --help