### PR TITLE
Skip coverage==4.3.0 due to the bug

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ pytest>=2.7,<=2.9.2
 pytest-cov>=2.2.1,<=2.3.0
 pytest-html==1.10.1
 
-coverage>=3.6
+coverage>=3.6,!=4.3.0
 ddt>=1.0.1
 mock>=2.0
 


### PR DESCRIPTION
https://bitbucket.org/ned/coveragepy/issues/540/cant-install-coverage-v43-into-under#comment-33189673